### PR TITLE
removed colon from api version value

### DIFF
--- a/examples/lwc/force-app/main/default/lwc/productDetails/productDetails.js-meta.xml
+++ b/examples/lwc/force-app/main/default/lwc/productDetails/productDetails.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>52:.0</apiVersion>
+    <apiVersion>52.0</apiVersion>
     <isExposed>true</isExposed>
     <masterLabel>B2B Sample Product Details</masterLabel>
     <targets>


### PR DESCRIPTION
Fix to API version - Removed colon from API version - was throwing error during deployment.
Error parsing file: LWC Metadata Xml Parser: Invalid Double: 52:.0 XML parse error: Invalid Double 52:.0