### PR TITLE
Update NamedCredentials.md

### DIFF
--- a/examples/lwc/docs/NamedCredentials.md
+++ b/examples/lwc/docs/NamedCredentials.md
@@ -93,7 +93,7 @@ There are 3 steps involved to create a named credential:
 -   Note:
 
     -   The URL that you are entering here is the hostname part of the _Callback URL_. (i.e. paste the _Callback URL_ and remove the part starts with "services/authcallback/CallMeBack_AuthProvider")
-    -   In the "Scope" field, enter: refresh_token offline_access
+    -   In the "Scope" field, enter: api web refresh_token offline_access
     -   Make sure to check “Allow Merge Fields in HTTP Body”
 
 -   ![01_NamedCredentials](images/01_NamedCredentials.png)


### PR DESCRIPTION
Scope field for named credentials also requires "api web" to make it work otherwise you will get an "INVALID SESSION ID - This session is not valid for use with the REST API" error as response (401).
Version: Winter '22 Patch 10.1